### PR TITLE
Fix Dropped Item Visibility and Public Parameter Color Inconsistency

### DIFF
--- a/src/main/java/org/sweetrazory/waystonesplus/eventhandlers/WaystoneBreak.java
+++ b/src/main/java/org/sweetrazory/waystonesplus/eventhandlers/WaystoneBreak.java
@@ -49,7 +49,7 @@ public class WaystoneBreak implements Listener {
                 Location dropLocation = event.getPlayer().getTargetBlock(null, 5).getLocation().add(0, 1, 0);
                 World world = event.getPlayer().getWorld();
                 String waystoneName = waystone.getName();
-                ItemStack skullItem = WaystoneSummonItem.getLodestoneHead(waystoneName, blockWaystoneType, null, null, Visibility.PRIVATE);
+                ItemStack skullItem = WaystoneSummonItem.getLodestoneHead(waystoneName, blockWaystoneType, null, null, waystone.getVisibility());
                 world.dropItemNaturally(dropLocation, skullItem);
                 waystone.delete();
             } else {

--- a/src/main/java/org/sweetrazory/waystonesplus/items/WaystoneSummonItem.java
+++ b/src/main/java/org/sweetrazory/waystonesplus/items/WaystoneSummonItem.java
@@ -54,7 +54,7 @@ public class WaystoneSummonItem {
         dataContainer.set(waystoneType, PersistentDataType.STRING, type);
         dataContainer.set(waystoneVisibility, PersistentDataType.STRING, visibility.name());
         itemMeta.setLore(new ArrayList<String>() {{
-            add(ColoredText.getText(visibility == Visibility.PRIVATE ? "&cPRIVATE" : visibility == Visibility.PUBLIC ? "&2PUBLIC" : "&eGLOBAL"));
+            add(ColoredText.getText(visibility == Visibility.PRIVATE ? "&cPRIVATE" : visibility == Visibility.PUBLIC ? "&aPUBLIC" : "&eGLOBAL"));
         }});
         skullItem.setItemMeta(itemMeta);
 


### PR DESCRIPTION
Fixed two problems:
- Fixed an issue where broken waystones always had private visibility.
- Addressed the problem where broken waystones with a public visibility setting were incorrectly changing color to dark green.